### PR TITLE
Routemanager

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -117,7 +117,7 @@ When a route registration fails (see exception), it is not added to the managed 
 
 The package gives an event source which can be used to detect changes in the routes which are managed by the operator. The changes are detected using the netlink kernel interface, filtered for route changes.
 
-When a managed route is deleted by an external entity, it is not auto-removed from the managed routes. It is the task of the event handler, so it has to deregister the route (and re-register if needed). Consequently if a route deletion during the deregistration causes error (route does not exist) it is still removed from the managed route list.
+When a managed route is deleted by an external entity, it is not auto-removed from the managed routes. It is the task of the event handler, so it has to deregister the route (and re-register if needed). Consequently if a route deletion during the deregistration causes error (route does not exist) it is still removed from the managed route list. Other errors are reported back to the requestor.
 
 The code is under `pkg/routemanager`
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -113,7 +113,7 @@ TODO: add package path
 ### Static route manager
 Since the IP routes on the nodes are essentially forming a state (in the kernel), those need to have a representation in the operator's scope and the controller loops (as state-less layers) can not own this data. This package provides ownership for the IP routes which are created by the operator. The package provides a permanent go-routine with function interfaces to manage static routes, including creating and deleting them.
 
-When a route registration fails, it is not added to the managed route list and the error is reported to the requestor.
+When a route registration fails (see exception), it is not added to the managed route list and the error is reported to the requestor. When the error is "file exists" (EEXIST = Errno(0x11)) it is accepted, assuming the route is created by ourselves, probably before a crash.
 
 The package gives an event source which can be used to detect changes in the routes which are managed by the operator. The changes are detected using the netlink kernel interface, filtered for route changes.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -111,11 +111,15 @@ TODO: add package path
 
 ## Other packages
 ### Static route manager
-Since the IP routes on the nodes are essentially forming a state (in the kernel), those need to have a representation in the operator's scope and the controller loops (as state-less layers) can not own this data. This package provides ownership for the IP routes which are created by the operator. The package provides a permanent go-routine with function interfaces to manage static routes, including creating, deleting and querying them.
+Since the IP routes on the nodes are essentially forming a state (in the kernel), those need to have a representation in the operator's scope and the controller loops (as state-less layers) can not own this data. This package provides ownership for the IP routes which are created by the operator. The package provides a permanent go-routine with function interfaces to manage static routes, including creating and deleting them.
 
-The package, moreover gives an event source which can be used to detect changes in the routes which are managed by the operator. The changes are detected using the netlink kernel interface, filtered for route changes. When a route add or delete request is handled, it shall be double-checked with the same event interface, before returning the request result to the sender (i.e. to return only if the route change is reported back by the kernel).
+When a route registration fails, it is not added to the managed route list and the error is reported to the requestor.
 
-TODO: add package path
+The package gives an event source which can be used to detect changes in the routes which are managed by the operator. The changes are detected using the netlink kernel interface, filtered for route changes.
+
+When a managed route is deleted by an external entity, it is not auto-removed from the managed routes. It is the task of the event handler, so it has to deregister the route (and re-register if needed). Consequently if a route deletion during the deregistration causes error (route does not exist) it is still removed from the managed route list.
+
+The code is under `pkg/routemanager`
 
 ## Metrics
 TODO

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.13
 
 require (
 	github.com/go-openapi/spec v0.19.0
+	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/operator-framework/operator-sdk v0.12.0
 	github.com/spf13/pflag v1.0.3
 	github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e
-	golang.org/x/sys v0.0.0-20190515120540-06a5c4944438
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
+	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v11.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/google/certificate-transparency-go v1.0.21/go.mod h1:QeJfpSbVSfYc7RgB
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
@@ -537,6 +539,8 @@ golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQeSA51uaEfbOW5dNb68=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181105165119-ca4130e427c7/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -565,6 +569,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438 h1:khxRGsvPk4n2y8I/mLLjp7e5dMTJmH75wvqS6nMwUtY=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db h1:6/JqlYfC1CCaLnGceQTI+sDGhC9UBSPAsBqI0Gun6kU=
@@ -593,6 +599,8 @@ golang.org/x/tools v0.0.0-20190624180213-70d37148ca0c/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20191018212557-ed542cd5b28a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v0.0.0-20160318181535-f6a740d52f96/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -287,9 +288,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/kr/fs v0.0.0-20131111012553-2788f0dbd169/go.mod h1:glhvuHOU9Hy7/8PwwdtnarXqLagOX0b/TbZx2zLMqEg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.0.0-20140812000539-f31442d60e51/go.mod h1:Bvhd+E3laJ0AVkG0c9rmtZcnhV0HQ3+c3YxxqTvc/gA=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.0.0-20130911015532-6807e777504f/go.mod h1:sjUstKUATFIcff4qlB53Kml0wQPtJVc/3fWrmuUmcfA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -598,6 +601,7 @@ gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmK
 google.golang.org/api v0.0.0-20181220000619-583d854617af/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20170731182057-09f6ed296fc6/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -610,6 +614,7 @@ google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=

--- a/pkg/routemanager/routemanager.go
+++ b/pkg/routemanager/routemanager.go
@@ -92,18 +92,16 @@ func (r *routeManagerImpl) deRegisterRoute(params routeManagerImplDeRegisterRout
 	params.err <- nil
 }
 
-func (r *routeManagerImpl) RegisterWatcher(w RouteWatcher) error {
+func (r *routeManagerImpl) RegisterWatcher(w RouteWatcher) {
 	r.registerWatcherChan <- w
-	return nil
 }
 
 func (r *routeManagerImpl) registerWatcher(w RouteWatcher) {
 	r.watchers = append(r.watchers, w)
 }
 
-func (r *routeManagerImpl) DeRegisterWatcher(w RouteWatcher) error {
+func (r *routeManagerImpl) DeRegisterWatcher(w RouteWatcher) {
 	r.deRegisterWatcherChan <- w
-	return nil
 }
 
 func (r *routeManagerImpl) deRegisterWatcher(w RouteWatcher) {
@@ -156,9 +154,11 @@ func (r *routeManagerImpl) notifyWatchers(update netlink.RouteUpdate) {
 	}
 }
 
-func (r *routeManagerImpl) Run(stopChan chan struct{}) {
+func (r *routeManagerImpl) Run(stopChan chan struct{}) error {
 	updateChan := make(chan netlink.RouteUpdate)
-	r.nlRouteSubscribeFunc(updateChan, stopChan)
+	if err := r.nlRouteSubscribeFunc(updateChan, stopChan); err != nil {
+		return err
+	}
 loop:
 	for {
 		select {
@@ -179,4 +179,5 @@ loop:
 			r.deRegisterRoute(params)
 		}
 	}
+	return nil
 }

--- a/pkg/routemanager/routemanager.go
+++ b/pkg/routemanager/routemanager.go
@@ -10,15 +10,15 @@ import (
 )
 
 type routeManagerImpl struct {
-	managedRoutes        map[string]Route
-	watchers             []RouteWatcher
-	nlRouteSubscribeFunc func(chan<- netlink.RouteUpdate, <-chan struct{}) error
-	nlRouteAddFunc       func(route *netlink.Route) error
-	nlRouteDelFunc       func(route *netlink.Route) error
-	registerRoute        chan routeManagerImplRegisterRouteParams
-	deRegisterRoute      chan routeManagerImplDeRegisterRouteParams
-	registerWatcher      chan RouteWatcher
-	deRegisterWatcher    chan RouteWatcher
+	managedRoutes         map[string]Route
+	watchers              []RouteWatcher
+	nlRouteSubscribeFunc  func(chan<- netlink.RouteUpdate, <-chan struct{}) error
+	nlRouteAddFunc        func(route *netlink.Route) error
+	nlRouteDelFunc        func(route *netlink.Route) error
+	registerRouteChan     chan routeManagerImplRegisterRouteParams
+	deRegisterRouteChan   chan routeManagerImplDeRegisterRouteParams
+	registerWatcherChan   chan RouteWatcher
+	deRegisterWatcherChan chan RouteWatcher
 }
 
 type routeManagerImplRegisterRouteParams struct {
@@ -35,37 +35,84 @@ type routeManagerImplDeRegisterRouteParams struct {
 //New creates a RouteManager for production use. It populates the routeManagerImpl structure with the final pointers to netlink package's functions.
 func New() RouteManager {
 	return &routeManagerImpl{
-		managedRoutes:        make(map[string]Route),
-		nlRouteSubscribeFunc: netlink.RouteSubscribe,
-		nlRouteAddFunc:       netlink.RouteAdd,
-		nlRouteDelFunc:       netlink.RouteDel,
-		registerRoute:        make(chan routeManagerImplRegisterRouteParams),
-		deRegisterRoute:      make(chan routeManagerImplDeRegisterRouteParams),
-		registerWatcher:      make(chan RouteWatcher),
-		deRegisterWatcher:    make(chan RouteWatcher),
+		managedRoutes:         make(map[string]Route),
+		nlRouteSubscribeFunc:  netlink.RouteSubscribe,
+		nlRouteAddFunc:        netlink.RouteAdd,
+		nlRouteDelFunc:        netlink.RouteDel,
+		registerRouteChan:     make(chan routeManagerImplRegisterRouteParams),
+		deRegisterRouteChan:   make(chan routeManagerImplDeRegisterRouteParams),
+		registerWatcherChan:   make(chan RouteWatcher),
+		deRegisterWatcherChan: make(chan RouteWatcher),
 	}
 }
 
 func (r *routeManagerImpl) RegisterRoute(name string, route Route) error {
 	errChan := make(chan error)
-	r.registerRoute <- routeManagerImplRegisterRouteParams{name, route, errChan}
+	r.registerRouteChan <- routeManagerImplRegisterRouteParams{name, route, errChan}
 	return <-errChan
+}
+
+func (r *routeManagerImpl) registerRoute(params routeManagerImplRegisterRouteParams) {
+	if _, alreadyExists := r.managedRoutes[params.name]; alreadyExists {
+		params.err <- errors.New("Route with the same Name already registered")
+		return
+	}
+	nlRoute := params.route.toNetLinkRoute()
+	/* If syscall returns EEXIST (file exists), it means the route already existing.
+	   There is no evidence that we created is before a crash, or someone else.
+	   We assume we created it and so start managing it again. */
+	if err := r.nlRouteAddFunc(&nlRoute); err != nil && syscall.EEXIST.Error() != err.Error() {
+		params.err <- err
+		return
+	}
+	r.managedRoutes[params.name] = params.route
+	params.err <- nil
 }
 
 func (r *routeManagerImpl) DeRegisterRoute(name string) error {
 	errChan := make(chan error)
-	r.deRegisterRoute <- routeManagerImplDeRegisterRouteParams{name, errChan}
+	r.deRegisterRouteChan <- routeManagerImplDeRegisterRouteParams{name, errChan}
 	return <-errChan
 }
 
+func (r *routeManagerImpl) deRegisterRoute(params routeManagerImplDeRegisterRouteParams) {
+	item, found := r.managedRoutes[params.name]
+	if !found {
+		params.err <- errors.New("Route could not found")
+		return
+	}
+	nlRoute := item.toNetLinkRoute()
+	/* We remove the route from the managed ones, regardless of the ESRCH (no such process) error from the lower layer.
+	   Error supposed to happen only when the route is already missing, which was reported to the watchers, so they know. */
+	if err := r.nlRouteDelFunc(&nlRoute); err != nil && syscall.ESRCH.Error() != err.Error() {
+		params.err <- err
+		return
+	}
+	delete(r.managedRoutes, params.name)
+	params.err <- nil
+}
+
 func (r *routeManagerImpl) RegisterWatcher(w RouteWatcher) error {
-	r.registerWatcher <- w
+	r.registerWatcherChan <- w
 	return nil
 }
 
+func (r *routeManagerImpl) registerWatcher(w RouteWatcher) {
+	r.watchers = append(r.watchers, w)
+}
+
 func (r *routeManagerImpl) DeRegisterWatcher(w RouteWatcher) error {
-	r.deRegisterWatcher <- w
+	r.deRegisterWatcherChan <- w
 	return nil
+}
+
+func (r *routeManagerImpl) deRegisterWatcher(w RouteWatcher) {
+	for index, item := range r.watchers {
+		if reflect.DeepEqual(item, w) {
+			r.watchers = append(r.watchers[:index], r.watchers[index+1:]...)
+			break
+		}
+	}
 }
 
 func (r Route) toNetLinkRoute() netlink.Route {
@@ -95,6 +142,20 @@ func fromNetLinkRoute(netlinkRoute netlink.Route) Route {
 	}
 }
 
+func (r *routeManagerImpl) notifyWatchers(update netlink.RouteUpdate) {
+	if update.Type != unix.RTM_DELROUTE {
+		return
+	}
+	for _, route := range r.managedRoutes {
+		if route.equal(fromNetLinkRoute(update.Route)) {
+			for _, watcher := range r.watchers {
+				watcher.RouteDeleted(fromNetLinkRoute(update.Route))
+			}
+			break
+		}
+	}
+}
+
 func (r *routeManagerImpl) Run(stopChan chan struct{}) {
 	updateChan := make(chan netlink.RouteUpdate)
 	r.nlRouteSubscribeFunc(updateChan, stopChan)
@@ -105,58 +166,17 @@ loop:
 			if !ok {
 				break loop
 			}
-			if update.Type != unix.RTM_DELROUTE {
-				break
-			}
-			for _, route := range r.managedRoutes {
-				if route.equal(fromNetLinkRoute(update.Route)) {
-					for _, watcher := range r.watchers {
-						watcher.RouteDeleted(fromNetLinkRoute(update.Route))
-					}
-					break
-				}
-			}
+			r.notifyWatchers(update)
 		case <-stopChan:
 			break loop
-		case watcher := <-r.registerWatcher:
-			r.watchers = append(r.watchers, watcher)
-		case watcher := <-r.deRegisterWatcher:
-			for index, item := range r.watchers {
-				if reflect.DeepEqual(item, watcher) {
-					r.watchers = append(r.watchers[:index], r.watchers[index+1:]...)
-					break
-				}
-			}
-		case params := <-r.registerRoute:
-			if _, alreadyExists := r.managedRoutes[params.name]; alreadyExists {
-				params.err <- errors.New("Route with the same Name already registered")
-				break
-			}
-			nlRoute := params.route.toNetLinkRoute()
-			/* If syscall returns EEXIST (file exists), it means the route already existing.
-			   There is no evidence that we created is before a crash, or someone else.
-			   We assume we created it and so start managing it again. */
-			if err := r.nlRouteAddFunc(&nlRoute); err != nil && syscall.EEXIST.Error() != err.Error() {
-				params.err <- err
-				break
-			}
-			r.managedRoutes[params.name] = params.route
-			params.err <- nil
-		case params := <-r.deRegisterRoute:
-			item, found := r.managedRoutes[params.name]
-			if !found {
-				params.err <- errors.New("Route could not found")
-				break
-			}
-			nlRoute := item.toNetLinkRoute()
-			/* We remove the route from the managed ones, regardless of the ESRCH (no such process) error from the lower layer.
-			   Error supposed to happen only when the route is already missing, which was reported to the watchers, so they know. */
-			if err := r.nlRouteDelFunc(&nlRoute); err != nil && syscall.ESRCH.Error() != err.Error() {
-				params.err <- err
-				break
-			}
-			delete(r.managedRoutes, params.name)
-			params.err <- nil
+		case watcher := <-r.registerWatcherChan:
+			r.registerWatcher(watcher)
+		case watcher := <-r.deRegisterWatcherChan:
+			r.deRegisterWatcher(watcher)
+		case params := <-r.registerRouteChan:
+			r.registerRoute(params)
+		case params := <-r.deRegisterRouteChan:
+			r.deRegisterRoute(params)
 		}
 	}
 }

--- a/pkg/routemanager/routemanager_test.go
+++ b/pkg/routemanager/routemanager_test.go
@@ -198,6 +198,7 @@ func TestRegisterRouteSuccess(t *testing.T) {
 
 	go testable.rm.RegisterRoute(gTestRouteName, gTestRoute)
 	addedRoute := <-addCalledWith
+	testable.stop()
 	if !addedRoute.Equal(gTestRoute.toNetLinkRoute()) {
 		t.Error("Route sent to netlink does not match with the original")
 	}
@@ -209,7 +210,6 @@ func TestRegisterRouteSuccess(t *testing.T) {
 		}
 	}
 
-	testable.stop()
 }
 
 func TestRegisterRouteFail(t *testing.T) {
@@ -267,6 +267,7 @@ func TestDeRegisterRouteAlreadyDeleted(t *testing.T) {
 
 	go testable.rm.DeRegisterRoute(gTestRouteName)
 	deletedRoute := <-delCalledWith
+	testable.stop()
 	if !deletedRoute.Equal(gTestRoute.toNetLinkRoute()) {
 		t.Error("Route sent to netlink does not match with the original")
 	}
@@ -274,7 +275,6 @@ func TestDeRegisterRouteAlreadyDeleted(t *testing.T) {
 		t.Error("managedRoute slice must be empty")
 	}
 
-	testable.stop()
 }
 
 func TestDeRegisterRouteUnknownError(t *testing.T) {

--- a/pkg/routemanager/routemanager_test.go
+++ b/pkg/routemanager/routemanager_test.go
@@ -4,16 +4,48 @@ import (
 	"net"
 	"sync"
 	"testing"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 type MockRouteWatcher struct {
+	routeDeletedCalledWith chan Route
 }
 
 func (m MockRouteWatcher) RouteDeleted(r Route) {
+	m.routeDeletedCalledWith <- r
+}
+
+var gMockUpdateChan chan<- netlink.RouteUpdate
+
+func mockRouteSubscribe(u chan<- netlink.RouteUpdate, c <-chan struct{}) error {
+	gMockUpdateChan = u
+	return nil
+}
+
+func mockRouteAdd(route *netlink.Route) error {
+	return nil
+}
+
+func mockRouteDel(route *netlink.Route) error {
+	return nil
+}
+
+func newMock() RouteManager {
+	return &routeManagerImpl{
+		nlSubscribeFunc:   mockRouteSubscribe,
+		nlAddRouteFunc:    mockRouteAdd,
+		nlDelRouteFunc:    mockRouteDel,
+		registerRoute:     make(chan routeManagerImplRegisterRouteParams),
+		deRegisterRoute:   make(chan routeManagerImplRegisterRouteParams),
+		registerWatcher:   make(chan RouteWatcher),
+		deRegisterWatcher: make(chan RouteWatcher),
+	}
 }
 
 func TestNothingBlocks(t *testing.T) {
-	rm := Init()
+	rm := New()
 	stopChan := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -28,5 +60,79 @@ func TestNothingBlocks(t *testing.T) {
 	rm.DeRegisterRoute(Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254})
 	rm.DeRegisterWatcher(mockWatcher)
 	close(stopChan)
+	wg.Wait()
+}
+
+func TestWatchNewRouteDoesNotTrigger(t *testing.T) {
+	rm := newMock()
+	stopChan := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		rm.Run(stopChan)
+		wg.Done()
+	}()
+	mockWatcher := MockRouteWatcher{routeDeletedCalledWith: make(chan Route)}
+	rm.RegisterWatcher(mockWatcher)
+
+	if gMockUpdateChan == nil {
+		t.Error("Update channel did not populate")
+	}
+	gMockUpdateChan <- netlink.RouteUpdate{Type: unix.RTM_NEWROUTE, Route: Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254}.toNetLinkRoute()}
+
+	rm.DeRegisterWatcher(mockWatcher)
+	close(stopChan)
+	wg.Wait()
+	select {
+	case <-mockWatcher.routeDeletedCalledWith:
+		t.Error("Mock must not be triggered with new route, only del")
+	default:
+	}
+}
+
+func TestWatch(t *testing.T) {
+	rm := newMock()
+	stopChan := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		rm.Run(stopChan)
+		wg.Done()
+	}()
+	mockWatcher := MockRouteWatcher{routeDeletedCalledWith: make(chan Route)}
+	testRoute := Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254}
+	rm.RegisterRoute(testRoute)
+	rm.RegisterWatcher(mockWatcher)
+
+	if gMockUpdateChan == nil {
+		t.Error("Update channel did not populate")
+	}
+	gMockUpdateChan <- netlink.RouteUpdate{Type: unix.RTM_DELROUTE, Route: testRoute.toNetLinkRoute()}
+
+	fromUpdate := <-mockWatcher.routeDeletedCalledWith
+	if !fromUpdate.toNetLinkRoute().Equal(testRoute.toNetLinkRoute()) {
+		t.Error("Route in update event must be the same which we sent in")
+	}
+
+	rm.DeRegisterRoute(Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254})
+	rm.DeRegisterWatcher(mockWatcher)
+	close(stopChan)
+	wg.Wait()
+}
+
+func TestWatchCloseUpdateChan(t *testing.T) {
+	rm := newMock()
+	stopChan := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		rm.Run(stopChan)
+		wg.Done()
+	}()
+	mockWatcher := MockRouteWatcher{routeDeletedCalledWith: make(chan Route)}
+	rm.RegisterWatcher(mockWatcher)
+
+	close(gMockUpdateChan)
+
 	wg.Wait()
 }

--- a/pkg/routemanager/routemanager_test.go
+++ b/pkg/routemanager/routemanager_test.go
@@ -1,7 +1,10 @@
 package routemanager
 
 import (
+	"errors"
 	"net"
+	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -18,71 +21,108 @@ func (m MockRouteWatcher) RouteDeleted(r Route) {
 }
 
 var gMockUpdateChan chan<- netlink.RouteUpdate
+var gTestRoute = Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254}
 
 func mockRouteSubscribe(u chan<- netlink.RouteUpdate, c <-chan struct{}) error {
 	gMockUpdateChan = u
 	return nil
 }
 
-func mockRouteAdd(route *netlink.Route) error {
+func dummyRouteAdd(route *netlink.Route) error {
 	return nil
 }
 
-func mockRouteDel(route *netlink.Route) error {
+func dummyRouteDel(route *netlink.Route) error {
 	return nil
 }
 
-func newMock() RouteManager {
-	return &routeManagerImpl{
-		nlSubscribeFunc:   mockRouteSubscribe,
-		nlAddRouteFunc:    mockRouteAdd,
-		nlDelRouteFunc:    mockRouteDel,
-		registerRoute:     make(chan routeManagerImplRegisterRouteParams),
-		deRegisterRoute:   make(chan routeManagerImplRegisterRouteParams),
-		registerWatcher:   make(chan RouteWatcher),
-		deRegisterWatcher: make(chan RouteWatcher),
+type testableRouteManager struct {
+	rm       RouteManager
+	wg       sync.WaitGroup
+	stopChan chan struct{}
+}
+
+func (m *testableRouteManager) start() {
+	m.wg.Add(1)
+	go func() {
+		m.rm.Run(m.stopChan)
+		m.wg.Done()
+	}()
+}
+
+func (m *testableRouteManager) stop() {
+	close(m.stopChan)
+	m.wg.Wait()
+}
+
+func newTestableRouteManager() testableRouteManager {
+	return testableRouteManager{
+		rm: &routeManagerImpl{
+			nlRouteSubscribeFunc: mockRouteSubscribe,
+			nlRouteAddFunc:       dummyRouteAdd,
+			nlRouteDelFunc:       dummyRouteDel,
+			registerRoute:        make(chan routeManagerImplRegisterRouteParams),
+			deRegisterRoute:      make(chan routeManagerImplRegisterRouteParams),
+			registerWatcher:      make(chan RouteWatcher),
+			deRegisterWatcher:    make(chan RouteWatcher),
+		},
+		wg:       sync.WaitGroup{},
+		stopChan: make(chan struct{}),
+	}
+}
+
+func TestNewDoesReturnValidManager(t *testing.T) {
+	rm := New()
+	//Pretty intuitive way to check if two function pointers are identical. Thanks for: https://github.com/stretchr/testify/issues/182#issuecomment-495359313
+	if runtime.FuncForPC(reflect.ValueOf(rm.(*routeManagerImpl).nlRouteAddFunc).Pointer()).Name() != runtime.FuncForPC(reflect.ValueOf(netlink.RouteAdd).Pointer()).Name() {
+		t.Error("nlRouteAddFunc function is not pointing to netlink package")
+	}
+	if runtime.FuncForPC(reflect.ValueOf(rm.(*routeManagerImpl).nlRouteDelFunc).Pointer()).Name() != runtime.FuncForPC(reflect.ValueOf(netlink.RouteDel).Pointer()).Name() {
+		t.Error("nlRouteDelFunc function is not pointing to netlink package")
+	}
+	if runtime.FuncForPC(reflect.ValueOf(rm.(*routeManagerImpl).nlRouteSubscribeFunc).Pointer()).Name() != runtime.FuncForPC(reflect.ValueOf(netlink.RouteSubscribe).Pointer()).Name() {
+		t.Error("nlRouteSubscribeFunc function is not pointing to netlink package")
+	}
+	if rm.(*routeManagerImpl).registerRoute == nil {
+		t.Error("registerRoute channel is not initialized")
+	}
+	if rm.(*routeManagerImpl).deRegisterRoute == nil {
+		t.Error("deRegisterRoute channel is not initialized")
+	}
+	if rm.(*routeManagerImpl).registerWatcher == nil {
+		t.Error("registerWatcher channel is not initialized")
+	}
+	if rm.(*routeManagerImpl).deRegisterWatcher == nil {
+		t.Error("deRegisterWatcher channel is not initialized")
 	}
 }
 
 func TestNothingBlocks(t *testing.T) {
-	rm := New()
-	stopChan := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		rm.Run(stopChan)
-		wg.Done()
-	}()
-	mockWatcher := MockRouteWatcher{}
-	rm.RegisterRoute(Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254})
-	rm.RegisterWatcher(mockWatcher)
+	testable := newTestableRouteManager()
+	testable.start()
+	defer testable.stop()
 
-	rm.DeRegisterRoute(Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254})
-	rm.DeRegisterWatcher(mockWatcher)
-	close(stopChan)
-	wg.Wait()
+	mockWatcher := MockRouteWatcher{}
+	testable.rm.RegisterRoute(gTestRoute)
+	testable.rm.RegisterWatcher(mockWatcher)
+
+	testable.rm.DeRegisterRoute(gTestRoute)
+	testable.rm.DeRegisterWatcher(mockWatcher)
 }
 
 func TestWatchNewRouteDoesNotTrigger(t *testing.T) {
-	rm := newMock()
-	stopChan := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		rm.Run(stopChan)
-		wg.Done()
-	}()
+	testable := newTestableRouteManager()
+	testable.start()
 	mockWatcher := MockRouteWatcher{routeDeletedCalledWith: make(chan Route)}
-	rm.RegisterWatcher(mockWatcher)
 
+	testable.rm.RegisterWatcher(mockWatcher)
 	if gMockUpdateChan == nil {
 		t.Error("Update channel did not populate")
 	}
-	gMockUpdateChan <- netlink.RouteUpdate{Type: unix.RTM_NEWROUTE, Route: Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254}.toNetLinkRoute()}
+	gMockUpdateChan <- netlink.RouteUpdate{Type: unix.RTM_NEWROUTE, Route: gTestRoute.toNetLinkRoute()}
+	testable.rm.DeRegisterWatcher(mockWatcher)
+	testable.stop()
 
-	rm.DeRegisterWatcher(mockWatcher)
-	close(stopChan)
-	wg.Wait()
 	select {
 	case <-mockWatcher.routeDeletedCalledWith:
 		t.Error("Mock must not be triggered with new route, only del")
@@ -90,49 +130,124 @@ func TestWatchNewRouteDoesNotTrigger(t *testing.T) {
 	}
 }
 
-func TestWatch(t *testing.T) {
-	rm := newMock()
-	stopChan := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		rm.Run(stopChan)
-		wg.Done()
-	}()
+func TestWatchDelRouteDoesNotTriggerIfNotWatched(t *testing.T) {
+	testable := newTestableRouteManager()
+	testable.start()
 	mockWatcher := MockRouteWatcher{routeDeletedCalledWith: make(chan Route)}
-	testRoute := Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254}
-	rm.RegisterRoute(testRoute)
-	rm.RegisterWatcher(mockWatcher)
+
+	testable.rm.RegisterWatcher(mockWatcher)
+	if gMockUpdateChan == nil {
+		t.Error("Update channel did not populate")
+	}
+	gMockUpdateChan <- netlink.RouteUpdate{Type: unix.RTM_DELROUTE, Route: gTestRoute.toNetLinkRoute()}
+
+	testable.stop()
+	select {
+	case <-mockWatcher.routeDeletedCalledWith:
+		t.Error("Mock must not be triggered with a route which is not watched")
+	default:
+	}
+}
+
+func TestWatch(t *testing.T) {
+	testable := newTestableRouteManager()
+	testable.start()
+	defer testable.stop()
+
+	mockWatcher := MockRouteWatcher{routeDeletedCalledWith: make(chan Route)}
+	testable.rm.RegisterRoute(gTestRoute)
+	testable.rm.RegisterWatcher(mockWatcher)
 
 	if gMockUpdateChan == nil {
 		t.Error("Update channel did not populate")
 	}
-	gMockUpdateChan <- netlink.RouteUpdate{Type: unix.RTM_DELROUTE, Route: testRoute.toNetLinkRoute()}
+	gMockUpdateChan <- netlink.RouteUpdate{Type: unix.RTM_DELROUTE, Route: gTestRoute.toNetLinkRoute()}
 
 	fromUpdate := <-mockWatcher.routeDeletedCalledWith
-	if !fromUpdate.toNetLinkRoute().Equal(testRoute.toNetLinkRoute()) {
+	if !fromUpdate.toNetLinkRoute().Equal(gTestRoute.toNetLinkRoute()) {
 		t.Error("Route in update event must be the same which we sent in")
 	}
 
-	rm.DeRegisterRoute(Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254})
-	rm.DeRegisterWatcher(mockWatcher)
-	close(stopChan)
-	wg.Wait()
+	testable.rm.DeRegisterRoute(gTestRoute)
+	testable.rm.DeRegisterWatcher(mockWatcher)
 }
 
 func TestWatchCloseUpdateChan(t *testing.T) {
-	rm := newMock()
-	stopChan := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		rm.Run(stopChan)
-		wg.Done()
-	}()
+	testable := newTestableRouteManager()
+	testable.start()
+
 	mockWatcher := MockRouteWatcher{routeDeletedCalledWith: make(chan Route)}
-	rm.RegisterWatcher(mockWatcher)
+	testable.rm.RegisterWatcher(mockWatcher)
 
 	close(gMockUpdateChan)
 
-	wg.Wait()
+	testable.wg.Wait()
+}
+
+func TestAddRouteSuccess(t *testing.T) {
+	testable := newTestableRouteManager()
+	addCalledWith := make(chan *netlink.Route)
+	testable.rm.(*routeManagerImpl).nlRouteAddFunc = func(route *netlink.Route) error {
+		addCalledWith <- route
+		return nil
+	}
+	testable.start()
+
+	go testable.rm.RegisterRoute(gTestRoute)
+	addedRoute := <-addCalledWith
+	if !addedRoute.Equal(gTestRoute.toNetLinkRoute()) {
+		t.Error("Route sent to netlink does not match with the original")
+	}
+	if len(testable.rm.(*routeManagerImpl).managedRoutes) != 1 {
+		t.Error("managedRoute slice must contain one element")
+	} else {
+		if !testable.rm.(*routeManagerImpl).managedRoutes[0].toNetLinkRoute().Equal(gTestRoute.toNetLinkRoute()) {
+			t.Error("Route stored in managedRoutes must be equal to the one which we created in the test")
+		}
+	}
+
+	testable.stop()
+}
+
+func TestAddRouteFail(t *testing.T) {
+	testable := newTestableRouteManager()
+	addCalledWith := make(chan *netlink.Route)
+	testable.rm.(*routeManagerImpl).nlRouteAddFunc = func(route *netlink.Route) error {
+		addCalledWith <- route
+		return errors.New("bla")
+	}
+	testable.start()
+
+	go testable.rm.RegisterRoute(gTestRoute)
+	addedRoute := <-addCalledWith
+	if !addedRoute.Equal(gTestRoute.toNetLinkRoute()) {
+		t.Error("Route sent to netlink does not match with the original")
+	}
+	if len(testable.rm.(*routeManagerImpl).managedRoutes) > 0 {
+		t.Error("managedRoute slice must be empty")
+	}
+
+	testable.stop()
+}
+
+func TestDelRouteFail(t *testing.T) {
+	testable := newTestableRouteManager()
+	delCalledWith := make(chan *netlink.Route)
+	testable.rm.(*routeManagerImpl).nlRouteDelFunc = func(route *netlink.Route) error {
+		delCalledWith <- route
+		return errors.New("bla")
+	}
+	testable.start()
+	testable.rm.RegisterRoute(gTestRoute)
+
+	go testable.rm.DeRegisterRoute(gTestRoute)
+	deletedRoute := <-delCalledWith
+	if !deletedRoute.Equal(gTestRoute.toNetLinkRoute()) {
+		t.Error("Route sent to netlink does not match with the original")
+	}
+	if len(testable.rm.(*routeManagerImpl).managedRoutes) > 0 {
+		t.Error("managedRoute slice must be empty")
+	}
+
+	testable.stop()
 }

--- a/pkg/routemanager/routemanager_test.go
+++ b/pkg/routemanager/routemanager_test.go
@@ -21,7 +21,7 @@ func (m MockRouteWatcher) RouteDeleted(r Route) {
 }
 
 var gMockUpdateChan chan<- netlink.RouteUpdate
-var gTestRoute = Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.IPMask{24}}, Gw: net.IP{192, 168, 1, 254}, Table: 254}
+var gTestRoute = Route{Dst: net.IPNet{IP: net.IP{192, 168, 1, 0}, Mask: net.CIDRMask(24, 32)}, Gw: net.IP{192, 168, 1, 254}, Table: 254}
 
 func mockRouteSubscribe(u chan<- netlink.RouteUpdate, c <-chan struct{}) error {
 	gMockUpdateChan = u

--- a/pkg/routemanager/routemanager_test.go
+++ b/pkg/routemanager/routemanager_test.go
@@ -187,7 +187,7 @@ func TestWatchCloseUpdateChan(t *testing.T) {
 	testable.wg.Wait()
 }
 
-func TestAddRouteSuccess(t *testing.T) {
+func TestRegisterRouteSuccess(t *testing.T) {
 	testable := newTestableRouteManager()
 	addCalledWith := make(chan *netlink.Route)
 	testable.rm.(*routeManagerImpl).nlRouteAddFunc = func(route *netlink.Route) error {
@@ -212,7 +212,7 @@ func TestAddRouteSuccess(t *testing.T) {
 	testable.stop()
 }
 
-func TestAddRouteFail(t *testing.T) {
+func TestRegisterRouteFail(t *testing.T) {
 	testable := newTestableRouteManager()
 	addCalledWith := make(chan *netlink.Route)
 	testable.rm.(*routeManagerImpl).nlRouteAddFunc = func(route *netlink.Route) error {
@@ -233,26 +233,29 @@ func TestAddRouteFail(t *testing.T) {
 	testable.stop()
 }
 
-func TestSameAddRouteFail(t *testing.T) {
+func TestSameRegisterRouteTwiceFail(t *testing.T) {
 	testable := newTestableRouteManager()
 	testable.start()
 
-	testable.rm.RegisterRoute(gTestRouteName, gTestRoute)
+	err := testable.rm.RegisterRoute(gTestRouteName, gTestRoute)
+	if err != nil {
+		t.Error("First RegisterRoute must pass")
+	}
 	if len(testable.rm.(*routeManagerImpl).managedRoutes) != 1 {
 		t.Error("managedRoute slice must contain the added route")
 	}
-	err := testable.rm.RegisterRoute(gTestRouteName, gTestRoute)
+	err = testable.rm.RegisterRoute(gTestRouteName, gTestRoute)
 	if err == nil {
 		t.Error("Adding the same route for the second time shall fail")
 	}
 	if len(testable.rm.(*routeManagerImpl).managedRoutes) != 1 {
-		t.Error("managedRoute slice must contain the added route")
+		t.Error("managedRoute slice must still contain the added route")
 	}
 
 	testable.stop()
 }
 
-func TestDelRouteAlreadyDeleted(t *testing.T) {
+func TestDeRegisterRouteAlreadyDeleted(t *testing.T) {
 	testable := newTestableRouteManager()
 	delCalledWith := make(chan *netlink.Route)
 	testable.rm.(*routeManagerImpl).nlRouteDelFunc = func(route *netlink.Route) error {
@@ -274,7 +277,7 @@ func TestDelRouteAlreadyDeleted(t *testing.T) {
 	testable.stop()
 }
 
-func TestDelRouteUnknownError(t *testing.T) {
+func TestDeRegisterRouteUnknownError(t *testing.T) {
 	testable := newTestableRouteManager()
 	delCalledWith := make(chan *netlink.Route)
 	testable.rm.(*routeManagerImpl).nlRouteDelFunc = func(route *netlink.Route) error {
@@ -296,7 +299,7 @@ func TestDelRouteUnknownError(t *testing.T) {
 	testable.stop()
 }
 
-func TestDelRouteWhichIsNotRegistered(t *testing.T) {
+func TestDeRegisterRouteWhichIsNotRegistered(t *testing.T) {
 	testable := newTestableRouteManager()
 	testable.start()
 	err := testable.rm.DeRegisterRoute(gTestRouteName)

--- a/pkg/routemanager/routemanager_test.go
+++ b/pkg/routemanager/routemanager_test.go
@@ -60,14 +60,14 @@ func (m *testableRouteManager) stop() {
 func newTestableRouteManager() testableRouteManager {
 	return testableRouteManager{
 		rm: &routeManagerImpl{
-			managedRoutes:        make(map[string]Route),
-			nlRouteSubscribeFunc: mockRouteSubscribe,
-			nlRouteAddFunc:       dummyRouteAdd,
-			nlRouteDelFunc:       dummyRouteDel,
-			registerRoute:        make(chan routeManagerImplRegisterRouteParams),
-			deRegisterRoute:      make(chan routeManagerImplDeRegisterRouteParams),
-			registerWatcher:      make(chan RouteWatcher),
-			deRegisterWatcher:    make(chan RouteWatcher),
+			managedRoutes:         make(map[string]Route),
+			nlRouteSubscribeFunc:  mockRouteSubscribe,
+			nlRouteAddFunc:        dummyRouteAdd,
+			nlRouteDelFunc:        dummyRouteDel,
+			registerRouteChan:     make(chan routeManagerImplRegisterRouteParams),
+			deRegisterRouteChan:   make(chan routeManagerImplDeRegisterRouteParams),
+			registerWatcherChan:   make(chan RouteWatcher),
+			deRegisterWatcherChan: make(chan RouteWatcher),
 		},
 		wg:       sync.WaitGroup{},
 		stopChan: make(chan struct{}),
@@ -86,21 +86,21 @@ func TestNewDoesReturnValidManager(t *testing.T) {
 	if runtime.FuncForPC(reflect.ValueOf(rm.(*routeManagerImpl).nlRouteSubscribeFunc).Pointer()).Name() != runtime.FuncForPC(reflect.ValueOf(netlink.RouteSubscribe).Pointer()).Name() {
 		t.Error("nlRouteSubscribeFunc function is not pointing to netlink package")
 	}
-	if rm.(*routeManagerImpl).registerRoute == nil {
+	if rm.(*routeManagerImpl).registerRouteChan == nil {
 		t.Error("registerRoute channel is not initialized")
 	}
-	if rm.(*routeManagerImpl).deRegisterRoute == nil {
+	if rm.(*routeManagerImpl).deRegisterRouteChan == nil {
 		t.Error("deRegisterRoute channel is not initialized")
 	}
-	if rm.(*routeManagerImpl).registerWatcher == nil {
+	if rm.(*routeManagerImpl).registerWatcherChan == nil {
 		t.Error("registerWatcher channel is not initialized")
 	}
-	if rm.(*routeManagerImpl).deRegisterWatcher == nil {
+	if rm.(*routeManagerImpl).deRegisterWatcherChan == nil {
 		t.Error("deRegisterWatcher channel is not initialized")
 	}
 }
 
-func TestNothingBlocks(t *testing.T) {
+func TestNothingBlocksInRun(t *testing.T) {
 	testable := newTestableRouteManager()
 	testable.start()
 	defer testable.stop()

--- a/pkg/routemanager/types.go
+++ b/pkg/routemanager/types.go
@@ -19,9 +19,9 @@ type RouteWatcher interface {
 //RouteManager is the main interface, which is implemented by the package
 type RouteManager interface {
 	//RegisterRoute creates and start watching the route. If the route is deleted after the registration, RouteWatchers will be notified.
-	RegisterRoute(Route) error
+	RegisterRoute(string, Route) error
 	//DeRegisterRoute removed the route from the kernel and also stop watching it.
-	DeRegisterRoute(Route) error
+	DeRegisterRoute(string) error
 	//RegisterWatcher registers a new RouteWatcher, which will be notified if the managed routes are deleted.
 	RegisterWatcher(RouteWatcher) error
 	//DeRegisterWatcher removes watchers

--- a/pkg/routemanager/types.go
+++ b/pkg/routemanager/types.go
@@ -23,9 +23,9 @@ type RouteManager interface {
 	//DeRegisterRoute removed the route from the kernel and also stop watching it.
 	DeRegisterRoute(string) error
 	//RegisterWatcher registers a new RouteWatcher, which will be notified if the managed routes are deleted.
-	RegisterWatcher(RouteWatcher) error
+	RegisterWatcher(RouteWatcher)
 	//DeRegisterWatcher removes watchers
-	DeRegisterWatcher(RouteWatcher) error
+	DeRegisterWatcher(RouteWatcher)
 	//Run is the main event loop, shall run in it's own go-routine. Returns when the channel sent in got closed.
-	Run(chan struct{})
+	Run(chan struct{}) error
 }


### PR DESCRIPTION
This package:
* manages the IP routes programmed in the kernel
* represents the state of the operator, so that the staticroute controller loop will contact this package
* there is a single instance is expected to run in the operator, in it's own go-routing

Features:
* add (register) IP routes based on an arbitrary name, IP subnet, gateway IP and routing table index and delete (deregister) based on the arbitrary name
* subscribe to the deletion event of the registered IP routes
* failure recovery (assuming any crash to the operator left routes programmed in the kernel)
  * if a registration founds the route already created, it still becomes managed
  * if a deregistration founds the route already deleted, it still becomes unmanaged
