### PR TITLE
Update iks.ibm.com_staticroutes_crd.yaml

### DIFF
--- a/deploy/crds/iks.ibm.com_staticroutes_crd.yaml
+++ b/deploy/crds/iks.ibm.com_staticroutes_crd.yaml
@@ -85,7 +85,6 @@ spec:
           required:
           - nodeStatus
           type: object
-      type: object
   version: v1
   versions:
   - name: v1


### PR DESCRIPTION
OpenShift 3.11 is not eating that line and it's not required by OpenShift 4.3.1 nor by Kubernetes 1.16.