### PR TITLE
Node label change detection.

### DIFF
--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -208,29 +207,6 @@ func TestMainImplHostnameMissing(t *testing.T) {
 	defer validateRecovery(t, "Missing environment variable: NODE_HOSTNAME")()
 	params, _ := getContextForHappyFlow()
 	params.getEnv = getEnvMock("", "", "", "")
-
-	mainImpl(*params)
-
-	t.Error("Error didn't appear")
-}
-
-func TestMainImplNodeGetFails(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			switch rt := r.(type) {
-			case error:
-				if rt.Error() != "nodes \"hostname\" not found" {
-					t.Errorf("Error not match, current %v", rt)
-				}
-			default:
-				t.Errorf("Wrong error did appear: %v", r)
-			}
-		}
-	}()
-	params, _ := getContextForHappyFlow()
-	params.newManager = func(*rest.Config, manager.Options) (manager.Manager, error) {
-		return mockManager{client: fake.NewFakeClient()}, nil
-	}
 
 	mainImpl(*params)
 

--- a/pkg/controller/staticroute/mocks_test.go
+++ b/pkg/controller/staticroute/mocks_test.go
@@ -141,7 +141,6 @@ func newStaticRouteWithValues(withSpec, withStatus bool) *iksv1.StaticRoute {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "CR",
 			Namespace: "default",
-			Labels:    map[string]string{ZoneLabel: "zone"},
 		},
 	}
 	if withSpec {

--- a/pkg/controller/staticroute/staticroute_controller.go
+++ b/pkg/controller/staticroute/staticroute_controller.go
@@ -100,7 +100,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
 				routes := &iksv1.StaticRouteList{}
 				if err := r.(*ReconcileStaticRoute).client.List(context.Background(), routes); err != nil {
-					//TODO escalate the problem somehow
+					log.Error(err, "Failed to List StaticRoute CRs")
 					return nil
 				}
 
@@ -122,10 +122,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			},
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				if len(e.MetaNew.GetLabels()) != len(e.MetaOld.GetLabels()) {
+					log.Info("Node label amount changed. Submitting all StaticRoute CRs for reconciliation.")
 					return true
 				}
 				for k, v := range e.MetaOld.GetLabels() {
 					if e.MetaNew.GetLabels()[k] != v {
+						log.Info("Node labels are changed. Submitting all StaticRoute CRs for reconciliation.")
 						return true
 					}
 				}

--- a/pkg/controller/staticroute/staticroute_controller_test.go
+++ b/pkg/controller/staticroute/staticroute_controller_test.go
@@ -104,20 +104,6 @@ func TestReconcileImplCRGetNotFound(t *testing.T) {
 	}
 }
 
-func TestReconcileImplNotSameZone(t *testing.T) {
-	params, _ := getReconcileContextForAddFlow(nil, true)
-	params.options.Zone = "a"
-
-	res, err := reconcileImpl(*params)
-
-	if res != notSameZone {
-		t.Error("Result must be notSameZone")
-	}
-	if err != nil {
-		t.Errorf("Error must be nil: %s", err.Error())
-	}
-}
-
 func TestReconcileImplProtected(t *testing.T) {
 	params, _ := getReconcileContextForAddFlow(nil, true)
 	params.options.ProtectedSubnets = []*net.IPNet{&net.IPNet{IP: net.IP{10, 0, 0, 0}, Mask: net.IPv4Mask(0xff, 0, 0, 0)}}
@@ -470,7 +456,6 @@ func getReconcileContextForAddFlow(route *iksv1.StaticRoute, isRegistered bool) 
 		client: newFakeClient(route),
 	}
 	params := newReconcileImplParams(&mockClient)
-	params.options.Zone = "zone"
 	params.options.Hostname = "hostname"
 	params.options.RouteManager = routeManagerMock{
 		isRegistered: isRegistered,

--- a/pkg/controller/staticroute/wrapper.go
+++ b/pkg/controller/staticroute/wrapper.go
@@ -99,6 +99,16 @@ func (rw *routeWrapper) addToStatus(hostname string, gateway net.IP) bool {
 	return true
 }
 
+func (rw *routeWrapper) alreadyInStatus(hostname string) bool {
+	for _, val := range rw.instance.Status.NodeStatus {
+		if val.Hostname == hostname {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (rw *routeWrapper) removeFromStatus(hostname string) (existed bool) {
 	// Update the status if necessary
 	statusArr := []iksv1.StaticRouteNodeStatus{}

--- a/pkg/controller/staticroute/wrapper.go
+++ b/pkg/controller/staticroute/wrapper.go
@@ -37,12 +37,6 @@ func (rw *routeWrapper) setFinalizer() bool {
 	return true
 }
 
-func (rw *routeWrapper) isSameZone(zone, label string) bool {
-	instanceZone := rw.instance.GetLabels()[label]
-
-	return instanceZone == "" || instanceZone == zone
-}
-
 func (rw *routeWrapper) isProtected(protecteds []*net.IPNet) bool {
 	_, subnetNet, err := net.ParseCIDR(rw.instance.Spec.Subnet)
 	if err != nil {

--- a/pkg/controller/staticroute/wrapper_test.go
+++ b/pkg/controller/staticroute/wrapper_test.go
@@ -24,61 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestIsSameZone(t *testing.T) {
-	var testData = []struct {
-		zone   string
-		route  *iksv1.StaticRoute
-		result bool
-	}{
-		{
-			"a",
-			&iksv1.StaticRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{ZoneLabel: "a"},
-				},
-			},
-			true,
-		},
-		{
-			"a",
-			&iksv1.StaticRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{ZoneLabel: ""},
-				},
-			},
-			true,
-		},
-		{
-			"",
-			&iksv1.StaticRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{ZoneLabel: ""},
-				},
-			},
-			true,
-		},
-		{
-			"a",
-			&iksv1.StaticRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{ZoneLabel: "b"},
-				},
-			},
-			false,
-		},
-	}
-
-	for i, td := range testData {
-		rw := routeWrapper{instance: td.route}
-
-		res := rw.isSameZone(td.zone, ZoneLabel)
-
-		if res != td.result {
-			t.Errorf("Result must be %t, it is %t at %d", td.result, res, i)
-		}
-	}
-}
-
 func TestIsProtected(t *testing.T) {
 	var testData = []struct {
 		protecteds []*net.IPNet

--- a/scripts/fvt-tools.sh
+++ b/scripts/fvt-tools.sh
@@ -77,10 +77,8 @@ check_route_in_container() {
   local test_type="${3:-positive}"
   for node in "${NODES[@]}"; do
     # Execute the command on all the nodes or only the given node
-    if [[ "${match_node}" != "all" ]] || 
-       [[ "${match_node}" != "${node}" ]]; then
-       continue
-    else
+    if [[ "${match_node}" == "all" ]] || 
+       [[ "${match_node}" == "${node}" ]]; then
       routes=$(docker exec "${node}" ip route)
       if [[ "${test_type}" == "positive" ]] &&
          [[ ${routes} == *${route}* ]]; then

--- a/scripts/run-fvt.sh
+++ b/scripts/run-fvt.sh
@@ -103,6 +103,12 @@ check_route_in_container "192.168.1.0/24 via 172.17.0.3"
 fvtlog "Test example-staticroute-with-selector - Check that only worker2 has applied the route to 192.168.2.0/24"
 check_route_in_container "192.168.2.0/24 via 172.17.0.1" "${KIND_CLUSTER_NAME}-worker" "negative"
 check_route_in_container "192.168.2.0/24 via 172.17.0.1" "${KIND_CLUSTER_NAME}-worker2"
+fvtlog "Test selected label is changed - worker2 has to remove it's route"
+kubectl label node ${KIND_CLUSTER_NAME}-worker2 kubernetes.io/hostname=temp --overwrite=true
+check_route_in_container "192.168.2.0/24 via 172.17.0.1" "${KIND_CLUSTER_NAME}-worker2" "negative"
+fvtlog "And then apply back the label - worker2 has to restore it's route"
+kubectl label node ${KIND_CLUSTER_NAME}-worker2 kubernetes.io/hostname=${KIND_CLUSTER_NAME}-worker2 --overwrite=true
+check_route_in_container "192.168.2.0/24 via 172.17.0.1" "${KIND_CLUSTER_NAME}-worker2"
 
 fvtlog "Test staticroute deletion"
 kubectl delete staticroute example-staticroute-simple


### PR DESCRIPTION
In the unlikely cases when the user is changing or removing a node label which was in the CRs selector, operator has to catch up and remove the route.
Also in the reverse case, if a node label is added after CR is created, operator need to operate :).

No extra API calls or watches are added as in the underlying informer caches are common and we are already watching the nodes.
