### PR TITLE
Enable error reporting in nodeStatus

### DIFF
--- a/pkg/controller/staticroute/wrapper.go
+++ b/pkg/controller/staticroute/wrapper.go
@@ -81,20 +81,23 @@ func (rw *routeWrapper) getGateway() net.IP {
 	return net.ParseIP(gateway)
 }
 
-func (rw *routeWrapper) addToStatus(hostname string, gateway net.IP) bool {
+func (rw *routeWrapper) addToStatus(hostname string, gateway net.IP, err error) bool {
 	// Update the status if necessary
 	for _, val := range rw.instance.Status.NodeStatus {
 		if val.Hostname == hostname {
 			return false
 		}
 	}
-
 	spec := rw.instance.Spec
 	spec.Gateway = gateway.String()
+	errorString := ""
+	if err != nil {
+		errorString = err.Error()
+	}
 	rw.instance.Status.NodeStatus = append(rw.instance.Status.NodeStatus, iksv1.StaticRouteNodeStatus{
 		Hostname: hostname,
 		State:    spec,
-		Error:    "",
+		Error:    errorString,
 	})
 	return true
 }

--- a/pkg/controller/staticroute/wrapper_test.go
+++ b/pkg/controller/staticroute/wrapper_test.go
@@ -17,6 +17,7 @@
 package staticroute
 
 import (
+	"errors"
 	"net"
 	"testing"
 
@@ -338,7 +339,7 @@ func TestRouteWrapperAddToStatus(t *testing.T) {
 	route := newStaticRouteWithValues(false, false)
 	rw := routeWrapper{instance: route}
 
-	added := rw.addToStatus("hostname", net.IP{10, 0, 0, 1})
+	added := rw.addToStatus("hostname", net.IP{10, 0, 0, 1}, errors.New("failure"))
 
 	if !added {
 		t.Error("Status must be added")
@@ -348,6 +349,8 @@ func TestRouteWrapperAddToStatus(t *testing.T) {
 		t.Errorf("First status must be `hostname`: %s", route.Status.NodeStatus[0].Hostname)
 	} else if route.Status.NodeStatus[0].State.Gateway != "10.0.0.1" {
 		t.Errorf("First status gateway must be `10.0.0.1`: %s", route.Status.NodeStatus[0].State.Gateway)
+	} else if route.Status.NodeStatus[0].Error != "failure" {
+		t.Errorf("Error field in status shall be filled with the string `failure`: %s", route.Status.NodeStatus[0].Error)
 	}
 }
 
@@ -362,7 +365,7 @@ func TestRouteWrapperAddToStatusNotAdded(t *testing.T) {
 	}
 	rw := routeWrapper{instance: route}
 
-	added := rw.addToStatus("hostname", net.IP{10, 0, 0, 1})
+	added := rw.addToStatus("hostname", net.IP{10, 0, 0, 1}, nil)
 
 	if added {
 		t.Error("Status must be not added")

--- a/scripts/fvt-tools.sh
+++ b/scripts/fvt-tools.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Wait loop configuration
-SLEEP_COUNT=30
-SLEEP_WAIT_SECONDS=2
+SLEEP_COUNT=10
+SLEEP_WAIT_SECONDS=6
 declare -a NODES
 
 fvtlog() {
@@ -16,34 +16,64 @@ list_nodes() {
 # Function to check the CR status
 # Parameters:
 # - CR name
-# - Node name (optional, needed when a CR applies only for a given node)
+# - Node name (optional, valid values: all_nodes_shall_post_status/nodes_shall_not_post_status/specific node)
+# - Error string to check (default is empty)
 check_staticroute_crd_status() {
   set +e
   local cr=$1
-  local match_node="${2:-all}"
+  local match_node="${2:-all_nodes_shall_post_status}"
+  local error_string="${3:-}"
   local status_ok=false
   for _ in $(seq ${SLEEP_COUNT}); do
-    if [[ "${match_node}" == "all" ]]; then
+    if [[ "${match_node}" == "all_nodes_shall_post_status" ]]; then
       cr_array=($(kubectl get staticroute "${cr}" --no-headers -o jsonpath='{.status.nodeStatus[*].hostname}'))
       if [[ ${#NODES[*]} -eq ${#cr_array[*]} ]]; then
-          status_ok=true
-          break
+        status_ok=true
+        break
       fi
     else
-      node=$(kubectl get staticroute "${cr}" --no-headers -o jsonpath='{.status.nodeStatus[*].hostname}' | grep "${match_node}")
-      if [[ "${node}" == "${node}" ]]; then
-          status_ok=true
-          break
+      node_exists=$(kubectl get staticroute "${cr}" --no-headers -o jsonpath='{.status.nodeStatus[*].hostname}' | grep -c "${match_node}")
+      if [[ "${node_exists}" == 1 ]]; then
+        status_ok=true
+        break
       fi
     fi
     sleep ${SLEEP_WAIT_SECONDS}
   done
-  if [[ $status_ok == false ]]; then
+
+  # So far, the script was waiting the wait loop, do one more check for the resource
+  if [[ "${match_node}" == "nodes_shall_not_post_status" ]]; then
+    node_status=$(kubectl get staticroute "${cr}" --no-headers -o jsonpath='{.status.nodeStatus[*]}')
+    cr_exists=$?
+    if [[ "${cr_exists}" == 0 ]] &&
+       [[ "${node_status}" == "" ]]; then
+      status_ok=true
+    fi
+  fi
+  # Get all the error fields and word by word put to an array
+  local error_array=($(kubectl get staticroute "${cr}" --no-headers -o jsonpath='{.status.nodeStatus[*].error}'))
+  if [[ "${error_string}" != "" ]]; then
+    if [[ "${#error_array[*]}" == 0 ]]; then
+      status_ok=false
+    else
+      for error in "${error_array[@]}"; do
+        if [[ "${error_string}" != *${error}* ]]; then
+          status_ok=false
+          break
+        fi
+      done
+    fi
+  elif [[ "${#error_array[*]}" != 0 ]]; then
+    fvtlog "Unexpected errors found: " "${error_array[@]}"
+    status_ok=false
+  fi
+  set -e
+
+  if [[ ${status_ok} == false ]]; then
     fvtlog "Failed to get the nodeStatus for the ${cr}. Are the operator pods running?"
     return 1
   fi
-  fvtlog "Passed: ${cr} status is updated and contains the necessary hosts."
-  set -e
+  fvtlog "Passed: ${cr} status is updated and contains the expected values."
 }
 
 # Function to check the staticroute-operator pods are all running
@@ -53,10 +83,10 @@ check_operator_is_running() {
   for _ in $(seq ${SLEEP_COUNT}); do
     number_of_pods_not_running=$(kubectl get pods --selector name=staticroute-operator --no-headers | grep -vc Running)
     if [[ $number_of_pods_not_running -eq 0 ]]; then
-        reached_expected_count=true
-        break
+      reached_expected_count=true
+      break
     else
-        sleep ${SLEEP_WAIT_SECONDS}
+      sleep ${SLEEP_WAIT_SECONDS}
     fi
   done
   if [[ $reached_expected_count == false ]]; then
@@ -75,10 +105,12 @@ check_route_in_container() {
   local route=$1
   local match_node="${2:-all}"
   local test_type="${3:-positive}"
+  local match=false
   for node in "${NODES[@]}"; do
     # Execute the command on all the nodes or only the given node
     if [[ "${match_node}" == "all" ]] || 
        [[ "${match_node}" == "${node}" ]]; then
+      match=true
       routes=$(docker exec "${node}" ip route)
       if [[ "${test_type}" == "positive" ]] &&
          [[ ${routes} == *${route}* ]]; then
@@ -93,4 +125,16 @@ check_route_in_container() {
       fi
     fi
   done
+  if [[ "${match}" == false ]]; then
+    fvtlog "Failure in check route on node: there were no matching node for the parameter ${match_node}!"
+    return 1
+  fi
+}
+
+label_nodes_with_default() {
+    local zone=$1
+    for node in "${NODES[@]}"; do
+      kubectl label node "${node}" failure-domain.beta.kubernetes.io/zone="${zone}" --overwrite
+      kubectl label node "${node}" kubernetes.io/hostname="${node}" --overwrite=true
+    done
 }


### PR DESCRIPTION
- Report error in the nodeStatus when it happens
- In certain cases, error shall be not reported - node selector does not match
- Update the FVT env and look for errors in the CR
 
Note: due to the removal of the meta.zone functionality, this change shall be revised.