### PR TITLE
Disable metrics in the operator, fix fvt on ibmcloud/roks

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"net"
@@ -28,7 +27,6 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 
-	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	kRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
@@ -43,14 +41,9 @@ import (
 	"github.com/IBM/staticroute-operator/version"
 	"github.com/vishvananda/netlink"
 
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
-	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -60,11 +53,7 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsHost                   = "0.0.0.0"
-	metricsPort             int32 = 8383
-	operatorMetricsPort     int32 = 8686
-	defaultMetricsNamespace       = "default"
-	defaultRouteTable             = 254
+	defaultRouteTable = 254
 )
 var log = logf.Log.WithName("cmd")
 
@@ -98,15 +87,12 @@ func main() {
 	printVersion()
 
 	mainImpl(mainImplParams{
-		logger:                log,
-		getEnv:                os.Getenv,
-		osEnv:                 os.Environ,
-		getConfig:             config.GetConfig,
-		newManager:            manager.New,
-		addToScheme:           apis.AddToScheme,
-		serveCRMetrics:        serveCRMetrics,
-		createMetricsService:  metrics.CreateMetricsService,
-		createServiceMonitors: metrics.CreateServiceMonitors,
+		logger:      log,
+		getEnv:      os.Getenv,
+		osEnv:       os.Environ,
+		getConfig:   config.GetConfig,
+		newManager:  manager.New,
+		addToScheme: apis.AddToScheme,
 		newKubernetesConfig: func(config *rest.Config) (discoverable, error) {
 			clientSet, err := kubernetes.NewForConfig(config)
 			return clientSet, err
@@ -144,9 +130,6 @@ type mainImplParams struct {
 	getConfig                func() (*rest.Config, error)
 	newManager               func(*rest.Config, manager.Options) (manager.Manager, error)
 	addToScheme              func(s *kRuntime.Scheme) error
-	serveCRMetrics           func(*rest.Config) error
-	createMetricsService     func(context.Context, *rest.Config, []v1.ServicePort) (*v1.Service, error)
-	createServiceMonitors    func(*rest.Config, string, []*v1.Service, ...metrics.ServiceMonitorUpdater) ([]*monitoringv1.ServiceMonitor, error)
 	newKubernetesConfig      func(*rest.Config) (discoverable, error)
 	newRouterManager         func() routemanager.RouteManager
 	addStaticRouteController func(manager.Manager, staticroute.ManagerOptions) error
@@ -170,7 +153,7 @@ func mainImpl(params mainImplParams) {
 	mgr, err := params.newManager(cfg, manager.Options{
 		Namespace:          "",
 		MapperProvider:     apiutil.NewDiscoveryRESTMapper,
-		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		MetricsBindAddress: "0",
 	})
 	if err != nil {
 		panic(err)
@@ -181,39 +164,6 @@ func mainImpl(params mainImplParams) {
 	// Setup Scheme for all resources
 	if err := params.addToScheme(mgr.GetScheme()); err != nil {
 		panic(err)
-	}
-
-	if err = params.serveCRMetrics(cfg); err != nil {
-		params.logger.Info("Could not generate and serve custom resource metrics", "error", err.Error())
-	}
-
-	// Add to the below struct any other metrics ports you want to expose.
-	servicePorts := []v1.ServicePort{
-		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
-	}
-	// Create Service object to expose the metrics port(s).
-	service, err := params.createMetricsService(context.Background(), cfg, servicePorts)
-	if err != nil {
-		params.logger.Info("Could not create metrics Service", "error", err.Error())
-	}
-
-	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
-	// necessary to configure Prometheus to scrape metrics from this operator.
-	services := []*v1.Service{service}
-	metricsNamespace := params.getEnv("METRICS_NS")
-	if len(metricsNamespace) == 0 {
-		metricsNamespace = defaultMetricsNamespace
-		params.logger.Info("METRICS_NS not defined.", "using", defaultMetricsNamespace)
-	}
-	_, err = params.createServiceMonitors(cfg, metricsNamespace, services)
-	if err != nil {
-		params.logger.Info("Could not create ServiceMonitor object", "error", err.Error())
-		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
-		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
-		if err == metrics.ErrServiceMonitorNotPresent {
-			params.logger.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
-		}
 	}
 
 	hostname := params.getEnv("NODE_HOSTNAME")
@@ -311,31 +261,4 @@ func collectProtectedSubnets(envVars []string) []*net.IPNet {
 		}
 	}
 	return protectedSubnets
-}
-
-// serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
-// It serves those metrics on "http://metricsHost:operatorMetricsPort".
-func serveCRMetrics(cfg *rest.Config) error {
-	// Below function returns filtered operator/CustomResource specific GVKs.
-	// For more control override the below GVK list with your own custom logic.
-	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
-	if err != nil {
-		return err
-	}
-	// Get the namespace the operator is currently deployed in.
-	/*
-		As suggested in: https://github.com/operator-framework/operator-sdk/issues/1858#issuecomment-548323725
-		operatorNs, err := k8sutil.GetOperatorNamespace()
-		if err != nil {
-			return err
-		} */
-	operatorNs := ""
-	// To generate metrics in other namespaces, add the values below.
-	ns := []string{operatorNs}
-	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/cmd/manager/mock_test.go
+++ b/cmd/manager/mock_test.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"net/http"
+
 	iksv1 "github.com/IBM/staticroute-operator/pkg/apis/iks/v1"
 	"github.com/IBM/staticroute-operator/pkg/routemanager"
 	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
@@ -30,7 +32,6 @@ import (
 	"k8s.io/client-go/rest"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -88,9 +89,6 @@ type mockCallbacks struct {
 	getConfigCalled                bool
 	newManagerCalled               bool
 	addToSchemeCalled              bool
-	serveCRMetricsCalled           bool
-	createMetricsServiceCalled     bool
-	createServiceMonitorsCalled    bool
 	newKubernetesConfigCalled      bool
 	newRouterManagerCalled         bool
 	addStaticRouteControllerCalled bool

--- a/scripts/fvt-tools.sh
+++ b/scripts/fvt-tools.sh
@@ -14,10 +14,14 @@ update_node_list() {
 }
 
 pick_non_master_node() {
-  for index in ${!NODES[*]}
-  do
-    kubectl get no "${NODES[$index]}" --show-labels | grep 'node-role.kubernetes.io/master=' > /dev/null && continue || echo -ne "${NODES[$index]}"; break
-  done
+  if [[ "${PROVIDER}" == "ibmcloud" ]]; then
+    echo -ne "${NODES[0]}"
+  else
+    for index in ${!NODES[*]}
+    do
+      kubectl get no "${NODES[$index]}" --show-labels | grep 'node-role.kubernetes.io/master=' > /dev/null && continue || echo -ne "${NODES[$index]}"; break
+    done
+  fi
 }
 
 create_hostnet_pods() {


### PR DESCRIPTION
I made this PR to disable the metrics support.
Why?
- As static route is a hostNetwork pod, it has problems with other operators on ROKS:
```
{"level":"info","ts":1590589105.728627,"logger":"cmd","msg":"Operator Version: 0.0.1"}
{"level":"info","ts":1590589105.728758,"logger":"cmd","msg":"Go Version: go1.13.5"}
{"level":"info","ts":1590589105.7287762,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1590589105.7287915,"logger":"cmd","msg":"Version of operator-sdk: v0.15.1"}
{"level":"info","ts":1590589107.7963555,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8383"}
{"level":"error","ts":1590589107.797539,"logger":"controller-runtime.metrics","msg":"metrics server failed to listen. You may want to disable the metrics server or use another port if it is due to conflicts","error":"error listening on 0.0.0.0:8383: listen tcp 0.0.0.0:8383: bind: address already in use","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/travis/gopath/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/metrics.NewListener\n\t/home/travis/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/metrics/listener.go:44\nsigs.k8s.io/controller-runtime/pkg/manager.New\n\t/home/travis/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/manager/manager.go:277\nmain.mainImpl\n\tstaticroute-operator/cmd/manager/main.go:170\nmain.main\n\tstaticroute-operator/cmd/manager/main.go:100\nruntime.main\n\t/home/travis/.gimme/versions/go1.13.5.linux.amd64/src/runtime/proc.go:203"}
{"level":"error","ts":1590589107.7977738,"logger":"cmd","msg":"","error":"error listening on 0.0.0.0:8383: listen tcp 0.0.0.0:8383: bind: address already in use","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/travis/gopath/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nmain.main.func1\n\tstaticroute-operator/cmd/manager/main.go:81\nruntime.gopanic\n\t/home/travis/.gimme/versions/go1.13.5.linux.amd64/src/runtime/panic.go:679\nmain.mainImpl\n\tstaticroute-operator/cmd/manager/main.go:176\nmain.main\n\tstaticroute-operator/cmd/manager/main.go:100\nruntime.main\n\t/home/travis/.gimme/versions/go1.13.5.linux.amd64/src/runtime/proc.go:203"}
```
- when there is no such issue, we still have these logs:
```
{"level":"info","ts":1590585038.8278453,"logger":"cmd","msg":"Could not create metrics Service","error":"failed to initialize service object for metrics: required env POD_NAME not set, please configure downward API"}
{"level":"info","ts":1590585038.8281376,"logger":"cmd","msg":"METRICS_NS not defined.","using":"default"}
```
- Gergo also thinks this is not needed
- Also, I think this feature was never tested
