### PR TITLE
FVT is now able to run the IBMCloud VPC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/IBM/staticroute-operator
 go 1.13
 
 require (
-	github.com/coreos/prometheus-operator v0.34.0
 	github.com/go-openapi/spec v0.19.4
 	github.com/googleapis/gnostic v0.3.1
 	github.com/operator-framework/operator-sdk v0.15.1

--- a/scripts/run-fvt.sh
+++ b/scripts/run-fvt.sh
@@ -15,10 +15,15 @@ IMAGEPULLSECRET="${IMAGEPULLSECRET:-}"
 cleanup() {
   fvtlog "Running cleanup, error code $?"
   delete_hostnet_pods
-  if [[ "${PROVIDER}" == "kind" ]] &&
-     [[ "${KEEP_ENV}" == "false" ]]; then
+  if [[ "${KEEP_ENV}" == "false" ]]; then
+    kubectl delete staticroute --all &>/dev/null
+    if [[ "${SKIP_OPERATOR_INSTALL}" == "false" ]]; then
+      manage_common_operator_resources "delete"
+    fi
+    if [[ "${PROVIDER}" == "kind" ]]; then
       kind delete cluster --name ${KIND_CLUSTER_NAME}
       rm -rf "${SCRIPT_PATH}"/kubeconfig.yaml
+    fi
   fi
 }
 
@@ -42,7 +47,7 @@ fi
 
 # Support for manual install
 if [[ "${SKIP_OPERATOR_INSTALL}" == false ]]; then
-    apply_common_operator_resources
+    manage_common_operator_resources "apply"
 fi
 
 # Get all the worker nodes

--- a/scripts/run-fvt.sh
+++ b/scripts/run-fvt.sh
@@ -199,7 +199,7 @@ else
   fvtlog "Test subnet protection"
   if [[ "${PROTECTED_SUBNET_TEST1}" && "${PROTECTED_SUBNET_TEST2}" ]]
   then
-    kubectl get ds staticroute-operator -n"$(get_sr_pod_ns)" -oyaml | \
+    kubectl get ds staticroute-operator -nkube-system -oyaml | \
       sed "s|env:|env:\n        - name: PROTECTED_SUBNET_TEST1\n          value: ${PROTECTED_SUBNET_TEST1}\n        - name: PROTECTED_SUBNET_TEST2\n          value: ${PROTECTED_SUBNET_TEST2}|"\
       | kubectl apply -f -
 


### PR DESCRIPTION
- get the right route according to the IBMCloud provider type
- in case of IBMCloud, use its registry to get busybox
- did run `go mod tidy`
- cleanup static route related resources
- fail if helper hostnet pods cannot start
