### PR TITLE
move to Go 1.13.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os: ["linux"]
 dist: bionic
 
 go:
-- "1.13.5"
+- "1.13.7"
 
 git:
     depth: 9999


### PR DESCRIPTION
PSIRT
reason for this PR: https://exchange.xforce.ibmcloud.com/vulnerabilities/178227

"Go is vulnerable to a denial of service. By sending a malformed X.509 certificate, a remote attacker could exploit this vulnerability to cause a system panic."