### PR TITLE
Fix fvt tests on IBMCloud provider

### DIFF
--- a/scripts/fvt-tools.sh
+++ b/scripts/fvt-tools.sh
@@ -62,12 +62,10 @@ exec_in_hostnet_of_node() {
 
 get_default_gw() {
   if [[ "${PROVIDER}" == "ibmcloud" ]]; then
-    provider_type=$(get_provider_type)
-    [[ ${provider_type} == "softlayer" ]] && v="10.0.0.0/8" || v="default"
+    echo "127.0.0.1"
   else
-    v="default"
+    exec_in_hostnet_of_node "${NODES[0]}" 'ip route' | grep "^default.*via.*dev" | awk '{print $3}'
   fi
-  exec_in_hostnet_of_node "${NODES[0]}" 'ip route' | grep "^${v}.*via.*dev" | awk '{print $3}'
 }
 
 get_provider_type() {


### PR DESCRIPTION
FVT tests might fail when cluster nodes get their IP addresses from different subnets, since always the first node IP is picked as a next-hop.