### PR TITLE
Final fix for fvt tests on IBMCloud provider

### DIFF
--- a/scripts/fvt-tools.sh
+++ b/scripts/fvt-tools.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Wait loop configuration
-SLEEP_COUNT=10
+SLEEP_COUNT=20
 SLEEP_WAIT_SECONDS=6
 declare -a NODES
 
@@ -61,11 +61,14 @@ exec_in_hostnet_of_node() {
 }
 
 get_default_gw() {
+  local nodename=${1}
   if [[ "${PROVIDER}" == "ibmcloud" ]]; then
-    echo "127.0.0.1"
+    provider_type=$(get_provider_type)
+    [[ ${provider_type} == "softlayer" ]] && v="10.0.0.0/8" || v="default"
   else
-    exec_in_hostnet_of_node "${NODES[0]}" 'ip route' | grep "^default.*via.*dev" | awk '{print $3}'
+    v="default"
   fi
+  exec_in_hostnet_of_node "${nodename}" 'ip route' | grep "^${v}.*via.*dev" | awk '{print $3}'
 }
 
 get_provider_type() {

--- a/scripts/fvt-tools.sh
+++ b/scripts/fvt-tools.sh
@@ -62,11 +62,9 @@ exec_in_hostnet_of_node() {
 
 get_default_gw() {
   local nodename=${1}
-  if [[ "${PROVIDER}" == "ibmcloud" ]]; then
-    provider_type=$(get_provider_type)
-    [[ ${provider_type} == "softlayer" ]] && v="10.0.0.0/8" || v="default"
-  else
-    v="default"
+  v="default"
+  if [[ "${PROVIDER}" == "ibmcloud" ]] && [[ "$(get_provider_type)" == "softlayer" ]]; then
+    v="10.0.0.0/8"
   fi
   exec_in_hostnet_of_node "${nodename}" 'ip route' | grep "^${v}.*via.*dev" | awk '{print $3}'
 }


### PR DESCRIPTION
this is a fix for the previous commit which was partly fixed the following issue: on clusters where workers got their IPs from different subnets, the FVT test might run into the following error:
`Given gateway IP is not directly routable, cannot setup the route` because of picking gateway IP from another subnet

this PR simplifies the gw related test cases in `ibmcloud` provider cases
