### PR TITLE
Fix loop

### DIFF
--- a/pkg/controller/staticroute/mocks_test.go
+++ b/pkg/controller/staticroute/mocks_test.go
@@ -71,15 +71,19 @@ func (m reconcileImplClientMock) Status() client.StatusWriter {
 }
 
 type statusWriterMock struct {
-	updateErr error
-	patchErr  error
+	updateCounter int
+	patchCounter  int
+	updateErr     error
+	patchErr      error
 }
 
-func (m statusWriterMock) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+func (m *statusWriterMock) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	m.updateCounter = m.updateCounter + 1
 	return m.updateErr
 }
 
-func (m statusWriterMock) Patch(context.Context, runtime.Object, client.Patch, ...client.PatchOption) error {
+func (m *statusWriterMock) Patch(context.Context, runtime.Object, client.Patch, ...client.PatchOption) error {
+	m.patchCounter = m.patchCounter + 1
 	return m.patchErr
 }
 

--- a/pkg/controller/staticroute/mocks_test.go
+++ b/pkg/controller/staticroute/mocks_test.go
@@ -71,6 +71,7 @@ func (m reconcileImplClientMock) Status() client.StatusWriter {
 }
 
 type statusWriterMock struct {
+	client        client.Client
 	updateCounter int
 	patchCounter  int
 	updateErr     error
@@ -79,11 +80,17 @@ type statusWriterMock struct {
 
 func (m *statusWriterMock) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
 	m.updateCounter = m.updateCounter + 1
+	if m.client != nil {
+		return m.client.Status().Update(ctx, obj, opts...)
+	}
 	return m.updateErr
 }
 
-func (m *statusWriterMock) Patch(context.Context, runtime.Object, client.Patch, ...client.PatchOption) error {
+func (m *statusWriterMock) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, patchOption ...client.PatchOption) error {
 	m.patchCounter = m.patchCounter + 1
+	if m.client != nil {
+		return m.client.Status().Patch(ctx, obj, patch, patchOption...)
+	}
 	return m.patchErr
 }
 

--- a/pkg/controller/staticroute/wrapper.go
+++ b/pkg/controller/staticroute/wrapper.go
@@ -81,6 +81,19 @@ func (rw *routeWrapper) getGateway() net.IP {
 	return net.ParseIP(gateway)
 }
 
+func (rw *routeWrapper) statusMatch(hostname string, gateway net.IP, err error) bool {
+	errText := ""
+	if err != nil {
+		errText = err.Error()
+	}
+	for _, val := range rw.instance.Status.NodeStatus {
+		if val.Hostname == hostname && val.State.Subnet == rw.instance.Spec.Subnet && val.State.Gateway == gateway.String() && val.Error == errText {
+			return true
+		}
+	}
+	return false
+}
+
 func (rw *routeWrapper) addToStatus(hostname string, gateway net.IP, err error) bool {
 	// Update the status if necessary
 	for _, val := range rw.instance.Status.NodeStatus {


### PR DESCRIPTION
When there is a no-op for a reconciliation, the status was updated always (as `reportStatus` is true by default). This causes another reconciliation, and so on...
Added a dirty way to detect if there would be any effective change in the status. If not, skip the update.

TODO: enhance the whole reconcile logic and note down if there was no effective operation on the CR data. So that the `reportStatus` field will deserve it's name :).
