### PR TITLE
Avoid false sed replace in managedFields

### DIFF
--- a/scripts/run-fvt.sh
+++ b/scripts/run-fvt.sh
@@ -214,7 +214,7 @@ else
   if [[ "${PROTECTED_SUBNET_TEST1}" && "${PROTECTED_SUBNET_TEST2}" ]]
   then
     kubectl get ds static-route-operator -nkube-system -oyaml | \
-      sed "s|env:|env:\n        - name: PROTECTED_SUBNET_TEST1\n          value: ${PROTECTED_SUBNET_TEST1}\n        - name: PROTECTED_SUBNET_TEST2\n          value: ${PROTECTED_SUBNET_TEST2}|" > operator.yaml
+      sed "s|- env:|- env:\n        - name: PROTECTED_SUBNET_TEST1\n          value: ${PROTECTED_SUBNET_TEST1}\n        - name: PROTECTED_SUBNET_TEST2\n          value: ${PROTECTED_SUBNET_TEST2}|" > operator.yaml
       cat operator.yaml
       kubectl apply -f operator.yaml
 


### PR DESCRIPTION
`kubectl get ds static-route-operator -nkube-system -oyaml` returns with:
```
...
     addonmanager.kubernetes.io/mode: Reconcile
     app: staticroute-operator
  managedFields:
   - apiVersion: apps/v1
     fieldsType: FieldsV1
     fieldsV1:
...
               k:{"name":"static-route-operator"}:
                 .: {}
                 f:env:
...
```
and `sed` also finds that `f:env` which is undesirable.