### PR TITLE
Run as nonroot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ if: branch !~ ^build-[0-9]*$ AND tag !~ ^build-[0-9]*$ AND branch !~ ^v[0-9]*.[0
 language: go
 
 os: ["linux"]
-dist: bionic
+dist: focal
 
 go:
 - "1.15.2"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO111MODULE:=on
-DOCKER_BUILDKIT=1
+export DOCKER_BUILDKIT=1
 GO_PACKAGES=$(shell go list ./... | grep -v /tests/)
 GO_FILES=$(shell find . -type f -name '*.go' -not -path "./.git/*")
 GOLANGCI_LINT_EXISTS:=$(shell golangci-lint --version 2>/dev/null)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,4 @@
 FROM scratch
 COPY build/_output/bin/staticroute-operator /staticroute-operator
+USER 2000:2000
 CMD ["/staticroute-operator"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,28 @@
-FROM scratch
+FROM debian:stretch AS builder
+
+RUN apt-get update && apt-get install -y libcap2-bin
+
+ENV USER=appuser
+ENV UID=10001
+ENV GID=10001
+
+RUN adduser \    
+    --disabled-password \    
+    --gecos "" \    
+    --home "/nonexistent" \    
+    --shell "/sbin/nologin" \    
+    --no-create-home \    
+    --uid "${UID}" \ 
+    "${USER}"
+
 COPY build/_output/bin/staticroute-operator /staticroute-operator
-USER 2000:2000
+RUN setcap cap_net_admin+ep /staticroute-operator
+RUN chmod go+x /staticroute-operator
+
+FROM scratch
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /staticroute-operator /staticroute-operator
+
+USER 10001:10001
 CMD ["/staticroute-operator"]

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,8 +20,8 @@ spec:
         image: REPLACE_IMAGE
         imagePullPolicy: Always
         securityContext:
-          runAsUser: 2000
-          runAsGroup: 2000
+          runAsUser: 10001
+          runAsGroup: 10001
           capabilities:
             add:
             - NET_ADMIN

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,8 @@ spec:
         image: REPLACE_IMAGE
         imagePullPolicy: Always
         securityContext:
+          runAsUser: 2000
+          runAsGroup: 2000
           capabilities:
             add:
             - NET_ADMIN


### PR DESCRIPTION
- export DOCKER_BUILDKIT is needed to copy extended attrs between docker build stages
- set NET_ADMIN capability for Go binary in build stage 0
- set +x for groups and others

~UPDATE: I set this PR to WIP since travis does not support buildkit. Need to find a new way to include the binary with extended attributes to the docker image.~

UPDATE2: using 'ubuntu focal' solved the BUILDKIT issue