### PR TITLE
fix fvt with multiple default entries

### DIFF
--- a/scripts/fvt-tools.sh
+++ b/scripts/fvt-tools.sh
@@ -66,7 +66,7 @@ get_default_gw() {
   if [[ "${PROVIDER}" == "ibmcloud" ]] && [[ "$(get_provider_type)" == "softlayer" ]]; then
     v="10.0.0.0/8"
   fi
-  exec_in_hostnet_of_node "${nodename}" 'ip route' | grep "^${v}.*via.*dev" | awk '{print $3}'
+  exec_in_hostnet_of_node "${nodename}" 'ip route' | grep "^${v}.*via.*dev" | tail -1 | awk '{print $3}'
 }
 
 get_provider_type() {


### PR DESCRIPTION
For cases when:
```
default via 10.240.64.1 dev ens3
default via 10.240.64.1 dev ens3 proto dhcp src 10.240.64.6 metric 100
```