### PR TITLE
Use ubi8/ubi-minimal for intermediate build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ RUN CGO_ENABLED=${CGO} GOOS=linux GOARCH=${ARCH} go build ${GOBUILDFLAGS} -o /st
 
 # Intermediate stage to apply capabilities
 FROM $INTERMEDIATE_IMAGE AS intermediate
-
-RUN apt-get update && apt-get install -y libcap2-bin
 COPY --from=builder /staticroute-operator /staticroute-operator
 RUN setcap cap_net_admin+ep /staticroute-operator
 RUN chmod go+x /staticroute-operator

--- a/Makefile.env
+++ b/Makefile.env
@@ -11,4 +11,4 @@ CONTROLLER_TOOLS_VERSION?=v0.16.2
 
 CGO?=0
 GOBUILDFLAGS?="-mod=mod -a"
-INTERMEDIATE_IMAGE?="debian:bookworm"
+INTERMEDIATE_IMAGE?="registry.access.redhat.com/ubi8/ubi-minimal"


### PR DESCRIPTION
- it has setcap binary by default