### PR TITLE
remove deprecated IBM related imagepullsecret

### DIFF
--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: static-route-operator
-imagePullSecrets:
-  - name: default-us-icr-io


### PR DESCRIPTION
No need this secret anymore also it is deprecated and removed.